### PR TITLE
TLF-37: Implement email notification of report submission for LMAR

### DIFF
--- a/apps/lmr/index.js
+++ b/apps/lmr/index.js
@@ -7,6 +7,7 @@ const SummaryPageBehaviour = require('hof').components.summary;
 module.exports = {
   name: 'lmr',
   baseUrl: '/',
+  confirmStep: '/summary',
   steps: {
     '/start': {
       next: 'tenancy-start'
@@ -14,35 +15,41 @@ module.exports = {
     '/tenancy-start': {
       fields: ['move-date'],
       next: '/tenant-details',
-      continueOnEdit: true
+      backLink: 'start'
     },
     '/tenant-details': {
       fields: ['tenant-full-name', 'tenant-dob', 'tenant-nationality'],
       next: '/property-address',
-      backLink: '/tenancy-start'
+      backLink: 'tenancy-start'
     },
     '/property-address': {
       fields: ['address-line-1', 'address-line-2', 'town-or-city', 'county', 'postcode'],
-      backLink: true,
-      next: '/landlord-details'
+      next: '/landlord-details',
+      backLink: 'tenant-details',
     },
     '/landlord-details': {
       fields: ['landlord-full-name', 'company-name', 'landlord-email', 'landlord-phone'],
-      backLink: true,
-      next: '/summary'
+      next: '/summary',
+      backLink: 'property-address',
     },
     '/summary': {
       behaviours: [SummaryPageBehaviour],
       template: 'confirm',
       sections: require('./sections/summary-data-sections'),
-      next: '/privacy'
+      next: '/privacy',
+      backLink: 'landlord-details'
     },
     '/privacy': {
       behaviours: [SummaryPageBehaviour, Submit],
       fields: ['privacy-check'],
       sections: require('./sections/summary-data-sections'),
-      backLink: true,
-      next: '/privacy-declaration'
+      next: '/privacy-declaration',
+      backLink: 'summary'
+    },
+    '/privacy-declaration': {
+      behaviours: ['complete'],
+      backLink: false,
+      clearSession: true
     }
   }
 };

--- a/apps/lmr/translations/src/en/pages.json
+++ b/apps/lmr/translations/src/en/pages.json
@@ -30,10 +30,14 @@
   "privacy": {
     "header": "Privacy policy",
     "title": "Landlords make a report",
-    "p1": "Before making a report you must be confident that an existing occupier on whom you carried out initial checks at the start of their tenancy no longer has the right to rent by <a href='https://www.gov.uk/government/publications/right-to-rent-document-checks-a-user-guide' class='govuk-link'>checking their relevant documents</a>.",
-    "p2": "If the documents are being held by the Home Office or the person has an outstanding application or appeal, you must get <a href='https://eforms.homeoffice.gov.uk/outreach/lcs-application.ofml' class='govuk-link'>verification from the Home Office</a> first regarding the person’s ongoing right to rent.",
-    "p3": "If you have not carried out further document checks on someone who is renting your property, but you suspect a person is in the UK illegally, you can report them in confidence by using the <a href='https://www.gov.uk/report-immigration-crime' class='govuk-link'>immigration crime reporting service</a>.",
-    "p4": "If you have problems accessing these forms or need help completing them, call the Landlords' Helpline on 0300 790 6268"
+    "p1": "The personal information entered on this form will be used for immigration control purposes. It may also be used to support the work of the Home Office and to prevent and detect fraud. The Home Office is the data controller in relation to the information provided, which will be processed in accordance with the Data Protection Act 2018.",
+    "p2": "To ensure the security of the information provided we will only send responses to the email address that the landlord entered on the form. For further information on how the Home Office uses personal data, please see our <a href='https://www.gov.uk/government/organisations/home-office/about/personal-information-charter'>Personal information charter</a>."
+  },
+  "privacy-declaration": {
+    "title": "Landlords make a report",
+    "confirmed": "Report submitted",
+    "p1": "Thank you for making a report to the Home Office about an existing occupant who no longer has the right to rent.",
+    "p2": "An email containing the details of the report has been sent to the address you provided. The email contains a unique reference number which you should keep safe, as you may need it to prove that you’re not liable for a civil penalty."
   },
   "confirm": {
     "sections": {
@@ -60,11 +64,11 @@
       "address-line-1": {
         "label": "Address line 1"
       },
-      "company-name": {
-        "label": "Company name"
+      "address-line-2": {
+        "label": "Address line 2"
       },
-      "landlord-email": {
-        "label": "Email address"
+      "town-or-city": {
+        "label": "Town / city"
       },
       "county": {
         "label": "County"

--- a/assets/scss/app.scss
+++ b/assets/scss/app.scss
@@ -230,6 +230,17 @@ header {
   padding: 15px !important;
 }
 
+.ref-number-heading {
+  margin-top: 0px !important;
+  margin-bottom: 10px !important;
+}
+
+.ref-number {
+  margin-top: 0px !important;
+  margin-bottom: 0px !important;
+  padding-bottom: 10px;
+}
+
 .autocomplete__hint,
 .autocomplete__input {
   -webkit-appearance: none;

--- a/config.js
+++ b/config.js
@@ -14,7 +14,8 @@ module.exports = {
     notifyApiKey: process.env.NOTIFY_STUB === 'true' ? 'USE_MOCK' : process.env.NOTIFY_KEY,
     userAuthTemplateId: process.env.USER_AUTHORISATION_TEMPLATE_ID,
     caseworkerEmail: process.env.CASEWORKER_EMAIL,
-    submissionTemplateId: process.env.SUBMISSION_TEMPLATE_ID
+    submissionTemplateId: process.env.SUBMISSION_TEMPLATE_ID,
+    caseworkerSubmissionTemplateId: process.env.CASEWORKER_SUBMISSION_TEMPLATE_ID
   },
   hosts: {
     acceptanceTests: process.env.ACCEPTANCE_HOST_NAME || `http://localhost:${process.env.PORT || 8080}`


### PR DESCRIPTION
## What
- Add email notification for caseworker [TLF-37](https://collaboration.homeoffice.gov.uk/jira/browse/TLF-37)
- Utilise email notification for the landlord from the merge branch

## Why
- For both the caseworker and landlord to receive an email notification regarding the LMAR submission

## How
- Add logic for sending an email to the caseworker in /behaviours/create-and-send-pdf.js
- Add reference to govNotify caseworker email template in config.js

## Testing
- Tests passing locally