### PR TITLE
WIP-DO-NOT-MERGE-TLF-39: Add placeholder to the Certs

### DIFF
--- a/kube/app/ingress-external.yml
+++ b/kube/app/ingress-external.yml
@@ -35,7 +35,7 @@ spec:
     {{ else if eq .KUBE_NAMESPACE .UAT_ENV }}
     - host: lmr.uat.sas-notprod.homeoffice.gov.uk
     {{ else if eq .KUBE_NAMESPACE .STG_ENV }}
-    - host: preprod.notprod.{{ .APP_NAME }}.homeoffice.gov.uk
+    - host: lmr.stg.sas.homeoffice.gov.uk
     {{ else }}
     - host: {{ .PRODUCTION_URL }}
     {{ end }}

--- a/kube/certs/certificate-external.yml
+++ b/kube/certs/certificate-external.yml
@@ -5,9 +5,9 @@ metadata:
   labels:
     cert-manager.io/solver: route53
 spec:
-  commonName: "*.sas-lmr-branch.homeoffice.gov.uk"
+  commonName: "*.{{ .BRANCH_ENV }}.homeoffice.gov.uk"
   dnsNames:
-  - "*.sas-lmr-branch.homeoffice.gov.uk"
+  - "*.{{ .BRANCH_ENV }}.homeoffice.gov.uk"
   issuerRef:
     kind: ClusterIssuer
     name: letsencrypt-prod

--- a/kube/certs/certificate-internal.yml
+++ b/kube/certs/certificate-internal.yml
@@ -5,9 +5,9 @@ metadata:
   labels:
     cert-manager.io/solver: route53
 spec:
-  commonName: "*.internal.sas-lmr-branch.homeoffice.gov.uk"
+  commonName: "*.internal.{{ .BRANCH_ENV }}.homeoffice.gov.uk"
   dnsNames:
-  - "*.internal.sas-lmr-branch.homeoffice.gov.uk"
+  - "*.internal.{{ .BRANCH_ENV }}.homeoffice.gov.uk"
   issuerRef:
     kind: ClusterIssuer
     name: letsencrypt-prod


### PR DESCRIPTION
What?

Invalid certs are used by the Environments (excluding branch env). Root cause is due to missing place holder to create certs for the relevant Envs
[https://collaboration.homeoffice.gov.uk/jira/browse/TLF-39](url)

Why?

We need different certs for diff envs

How?

![image](https://github.com/UKHomeOffice/lmr/assets/146218064/37c70a50-c1ca-46ca-90fd-43d60478bbe8)
![image](https://github.com/UKHomeOffice/lmr/assets/146218064/57beb67c-c1c0-4848-bb07-496e55ad6d7a)



