### PR TITLE
TLF-79: Resolve PayloadTooLargeError

### DIFF
--- a/apps/lmr/fields/index.js
+++ b/apps/lmr/fields/index.js
@@ -9,8 +9,8 @@ module.exports = {
     validate: ['required', 'notUrl', 'date', 'before', { type: 'after', arguments: '2014-11-30' }]
   }),
   'tenant-full-name': {
-    mixin: 'input-text',
-    validate: ['required', 'notUrl']
+    validate: ['required', 'notUrl', { type: 'maxlength', arguments: [1000] }],
+    className: ['govuk-input']
   },
   'tenant-dob': dateComponent('tenant-dob', {
     isPageHeading: false,
@@ -27,19 +27,19 @@ module.exports = {
   },
   'address-line-1': {
     mixin: 'input-text',
-    validate: ['required', 'notUrl']
+    validate: ['required', 'notUrl', { type: 'maxlength', arguments: [250] }]
   },
   'address-line-2': {
     mixin: 'input-text',
-    validate: 'notUrl'
+    validate: ['notUrl', { type: 'maxlength', arguments: [250] }]
   },
   'town-or-city': {
     mixin: 'input-text',
-    validate: ['required', 'notUrl']
+    validate: ['required', 'notUrl', { type: 'maxlength', arguments: [250] }]
   },
   county: {
     mixin: 'input-text',
-    validate: 'notUrl'
+    validate: ['notUrl', { type: 'maxlength', arguments: [250] }]
   },
   postcode: {
     mixin: 'input-text',
@@ -52,19 +52,19 @@ module.exports = {
   },
   'landlord-full-name': {
     mixin: 'input-text',
-    validate: ['required', 'notUrl']
+    validate: ['required', 'notUrl', { type: 'maxlength', arguments: [1000] }]
   },
   'company-name': {
     mixin: 'input-text',
-    validate: 'notUrl'
+    validate: ['notUrl', { type: 'maxlength', arguments: [200] }]
   },
   'landlord-email': {
     mixin: 'input-text',
-    validate: ['required', 'email']
+    validate: ['required', 'email', { type: 'maxlength', arguments: [254] }]
   },
   'landlord-phone': {
     mixin: 'input-text',
-    validate: ['internationalPhoneNumber', 'notUrl', {type: 'maxlength', arguments: [200]}]
+    validate: ['internationalPhoneNumber', 'notUrl', {type: 'maxlength', arguments: [16]}]
   },
   'privacy-check': {
     mixin: 'checkbox',

--- a/apps/lmr/translations/src/en/validation.json
+++ b/apps/lmr/translations/src/en/validation.json
@@ -8,7 +8,8 @@
   },
   "tenant-full-name": {
     "required": "Enter tenant's full name",
-    "notUrl": "Please do not enter a link/url into your answers"
+    "notUrl": "Please do not enter a link/url into your answers",
+    "maxlength": "Full name must be 1000 characters or less"
   },
   "tenant-dob": {
     "required": "Please enter the tenant's date of birth",
@@ -22,17 +23,21 @@
   },
   "address-line-1": {
     "required": "Enter the property address line 1",
-    "notUrl": "Please do not enter a link/URL into your answers"
+    "notUrl": "Please do not enter a link/URL into your answers",
+    "maxlength": "Address line 1 must be 250 characters or less"
   },
   "address-line-2": {
-    "notUrl": "Please do not enter a link/URL into your answers"
+    "notUrl": "Please do not enter a link/URL into your answers",
+    "maxlength": "Address line 2 must be 250 characters or less"
   },
   "town-or-city": {
     "required": "Enter the town/city",
-    "notUrl": "Please do not enter a link/URL into your answers"
+    "notUrl": "Please do not enter a link/URL into your answers",
+    "maxlength": "Town/City must be 250 characters or less"
   },
   "county": {
-    "notUrl": "Please do not enter a link/URL into your answers"
+    "notUrl": "Please do not enter a link/URL into your answers",
+    "maxlength": "County must be 250 characters or less"
   },
   "postcode": {
     "required": "Enter the postcode of the rental property",
@@ -42,18 +47,22 @@
   },
   "landlord-full-name": {
     "required": "Enter the landlord's full name",
-    "notUrl": "Please do not enter a link/URL into your answers"
+    "notUrl": "Please do not enter a link/URL into your answers",
+    "maxlength": "Landlord's or agent's full name must be 1000 characters or less"
   },
   "company-name": {
-    "notUrl": "Please do not enter a link/URL into your answers"
+    "notUrl": "Please do not enter a link/URL into your answers",
+    "maxlength": "Company name must be 200 characters or less"
   },
   "landlord-email": {
     "required": "Enter the landlord's email",
-    "email": "Enter a valid email"
+    "email": "Enter a valid email",
+    "maxlength": "Email address must be 254 characters or less"
   },
   "landlord-phone": {
     "notUrl": "Please do not enter a link/URL into your answers",
-    "internationalPhoneNumber": "Enter a valid phone number"
+    "internationalPhoneNumber": "Enter a valid phone number",
+    "maxlength": "Telephone number must be 16 characters or less"
   },
   "privacy-check": {
     "required": "You must select the checkbox before submitting"


### PR DESCRIPTION
## What
- Resolve PayloadTooLargeError: request entity too large issue [TLF-79](https://collaboration.homeoffice.gov.uk/jira/browse/TLF-79)

## Why
- To validate the field lengths and not encounter this error

## How
- Add `maxlength` property to all necessary fields, in line with the latest Figma specifications, to /fields/index.js
- Add validation messages for the maxlength of the fields in validation.json

## Testing
- Tests passing locally