### PR TITLE
Validation error message changed for privacy policy page

### DIFF
--- a/apps/lmr/translations/src/en/validation.json
+++ b/apps/lmr/translations/src/en/validation.json
@@ -56,6 +56,6 @@
     "internationalPhoneNumber": "Enter a valid phone number"
   },
   "privacy-check": {
-    "required": "You must select the checkbox before submitting"
+    "required": "Confirm you have read the Data Protection statement"
   }
 }


### PR DESCRIPTION
### What

- TLF LMR - error message does not match design documentation- [TLF-104](https://collaboration.homeoffice.gov.uk/jira/browse/TLF-104)

### Why

- One of the error messages does not match the excel documentation.

### How

- Analysed and Identified the code changes to fix the mentioned issues
- Fixed the code as per the requirement
  - apps/lmr/translations/src/en/validation.json
  

### Testing
- [x] Local testing passed
- [x] Unit test passed in Local
- [x] Test Lint Passed in Local
- [x] Pipeline Check Passed
- [x] Branch Testing passed 