### PR TITLE
TLF-103- Page titles should match h1 headings - changes done as expected

### DIFF
--- a/apps/lmr/translations/src/en/journey.json
+++ b/apps/lmr/translations/src/en/journey.json
@@ -1,4 +1,5 @@
 {
   "header": "Landlords - make a report",
+  "serviceName": "Landlords make a report",
   "phase": "beta"
 }

--- a/apps/lmr/translations/src/en/pages.json
+++ b/apps/lmr/translations/src/en/pages.json
@@ -1,40 +1,41 @@
 {
   "start": {
     "header": "Make a report",
-    "title": "Landlords make a report",
+    "title": "Make a report – Landlords make a report",
     "p1": "Before making a report you must be confident that an existing occupier on whom you carried out initial checks at the start of their tenancy no longer has the right to rent by <a href='https://www.gov.uk/government/publications/right-to-rent-document-checks-a-user-guide' class='govuk-link'>checking their relevant documents</a>.",
     "p2": "If the documents are being held by the Home Office or the person has an outstanding application or appeal, you must get <a href='https://eforms.homeoffice.gov.uk/outreach/lcs-application.ofml' class='govuk-link'>verification from the Home Office</a> first regarding the person’s ongoing right to rent.",
     "p3": "If you have not carried out further document checks on someone who is renting your property, but you suspect a person is in the UK illegally, you can report them in confidence by using the <a href='https://www.gov.uk/report-immigration-crime' class='govuk-link'>immigration crime reporting service</a>.",
     "p4": "If you have problems accessing these forms or need help completing them, call the Landlords' Helpline on 0300 790 6268"
   },
   "tenancy-start": {
-    "title": "Landlords make a report",
+    "title": "When did the person move into your property? – Landlords make a report",
     "header": "When did the person move into your property?"
   },
   "tenant-details": {
-    "title": "Landlords make a report",
+    "title": "Existing tenant's information – Landlords make a report",
     "header": "Existing tenant's information"
   },
   "property-address": {
     "header": "Rental property address",
-    "title": "Landlords make a report",
+    "title": "Rental property address – Landlords make a report",
     "p1": "The address must be in England. You do not need to check a tenant's right to rent for properties in Wales, Scotland or Northern Ireland."
   },
   "landlord-details": {
     "header": "Landlord's or agent's information",
-    "title": "Landlords make a report"
+    "title": "Landlord's or agent's information – Landlords make a report"
   },
   "summary": {
-    "header": "Summary"
+    "header": "Summary",
+    "title": "Summary – Landlords make a report"
   },
   "privacy": {
     "header": "Privacy policy",
-    "title": "Landlords make a report",
+    "title": "Privacy policy – Landlords make a report",
     "p1": "The personal information entered on this form will be used for immigration control purposes. It may also be used to support the work of the Home Office and to prevent and detect fraud. The Home Office is the data controller in relation to the information provided, which will be processed in accordance with the Data Protection Act 2018.",
     "p2": "To ensure the security of the information provided we will only send responses to the email address that the landlord entered on the form. For further information on how the Home Office uses personal data, please see our <a href='https://www.gov.uk/government/organisations/home-office/about/personal-information-charter'>Personal information charter</a>."
   },
   "privacy-declaration": {
-    "title": "Landlords make a report",
+    "title": "Report submitted – Landlords make a report",
     "confirmed": "Report submitted",
     "p1": "Thank you for making a report to the Home Office about an existing occupant who no longer has the right to rent.",
     "p2": "An email containing the details of the report has been sent to the address you provided. The email contains a unique reference number which you should keep safe, as you may need it to prove that you’re not liable for a civil penalty."

--- a/apps/lmr/translations/src/en/pages.json
+++ b/apps/lmr/translations/src/en/pages.json
@@ -1,41 +1,33 @@
 {
   "start": {
     "header": "Make a report",
-    "title": "Make a report – Landlords make a report",
     "p1": "Before making a report you must be confident that an existing occupier on whom you carried out initial checks at the start of their tenancy no longer has the right to rent by <a href='https://www.gov.uk/government/publications/right-to-rent-document-checks-a-user-guide' class='govuk-link'>checking their relevant documents</a>.",
     "p2": "If the documents are being held by the Home Office or the person has an outstanding application or appeal, you must get <a href='https://eforms.homeoffice.gov.uk/outreach/lcs-application.ofml' class='govuk-link'>verification from the Home Office</a> first regarding the person’s ongoing right to rent.",
     "p3": "If you have not carried out further document checks on someone who is renting your property, but you suspect a person is in the UK illegally, you can report them in confidence by using the <a href='https://www.gov.uk/report-immigration-crime' class='govuk-link'>immigration crime reporting service</a>.",
     "p4": "If you have problems accessing these forms or need help completing them, call the Landlords' Helpline on 0300 790 6268"
   },
   "tenancy-start": {
-    "title": "When did the person move into your property? – Landlords make a report",
     "header": "When did the person move into your property?"
   },
   "tenant-details": {
-    "title": "Existing tenant's information – Landlords make a report",
     "header": "Existing tenant's information"
   },
   "property-address": {
     "header": "Rental property address",
-    "title": "Rental property address – Landlords make a report",
     "p1": "The address must be in England. You do not need to check a tenant's right to rent for properties in Wales, Scotland or Northern Ireland."
   },
   "landlord-details": {
-    "header": "Landlord's or agent's information",
-    "title": "Landlord's or agent's information – Landlords make a report"
+    "header": "Landlord's or agent's information"
   },
   "summary": {
-    "header": "Summary",
-    "title": "Summary – Landlords make a report"
+    "header": "Summary"
   },
   "privacy": {
     "header": "Privacy policy",
-    "title": "Privacy policy – Landlords make a report",
     "p1": "The personal information entered on this form will be used for immigration control purposes. It may also be used to support the work of the Home Office and to prevent and detect fraud. The Home Office is the data controller in relation to the information provided, which will be processed in accordance with the Data Protection Act 2018.",
     "p2": "To ensure the security of the information provided we will only send responses to the email address that the landlord entered on the form. For further information on how the Home Office uses personal data, please see our <a href='https://www.gov.uk/government/organisations/home-office/about/personal-information-charter'>Personal information charter</a>."
   },
   "privacy-declaration": {
-    "title": "Report submitted – Landlords make a report",
     "confirmed": "Report submitted",
     "p1": "Thank you for making a report to the Home Office about an existing occupant who no longer has the right to rent.",
     "p2": "An email containing the details of the report has been sent to the address you provided. The email contains a unique reference number which you should keep safe, as you may need it to prove that you’re not liable for a civil penalty."

--- a/apps/lmr/views/confirm.html
+++ b/apps/lmr/views/confirm.html
@@ -1,7 +1,4 @@
 {{<partials-page}}
-{{$pageTitle}}
-{{#t}}pages.summary.title{{/t}} – GOV.UK
-{{/pageTitle}}
   {{$page-content}}
     <p class="govuk-body">Check these details carefully before continuing. If any of the details are incorrect, change them.</p>
 

--- a/apps/lmr/views/confirm.html
+++ b/apps/lmr/views/confirm.html
@@ -1,4 +1,7 @@
 {{<partials-page}}
+{{$pageTitle}}
+{{#t}}pages.summary.title{{/t}} – GOV.UK
+{{/pageTitle}}
   {{$page-content}}
     <p class="govuk-body">Check these details carefully before continuing. If any of the details are incorrect, change them.</p>
 

--- a/apps/lmr/views/landlord-details.html
+++ b/apps/lmr/views/landlord-details.html
@@ -1,7 +1,4 @@
 {{<partials-page}}
-{{$pageTitle}}
-{{#t}}pages.landlord-details.title{{/t}} – GOV.UK
-{{/pageTitle}}
   {{$page-content}}
     {{#renderField}}landlord-full-name{{/renderField}}
     {{#renderField}}company-name{{/renderField}}

--- a/apps/lmr/views/landlord-details.html
+++ b/apps/lmr/views/landlord-details.html
@@ -1,5 +1,7 @@
-<title>{{#t}}pages.landlord-details.title{{/t}} – GOV.UK</title>
 {{<partials-page}}
+{{$pageTitle}}
+{{#t}}pages.landlord-details.title{{/t}} – GOV.UK
+{{/pageTitle}}
   {{$page-content}}
     {{#renderField}}landlord-full-name{{/renderField}}
     {{#renderField}}company-name{{/renderField}}

--- a/apps/lmr/views/layout.html
+++ b/apps/lmr/views/layout.html
@@ -1,0 +1,61 @@
+{{<govuk-template}}
+  {{$head}}
+    {{> partials-head}}
+  {{/head}}
+  {{$pageTitle}}
+    {{#errorlist.length}}{{#t}}errorlist.prefix{{/t}}{{/errorlist.length}}{{title}} &ndash; {{#t}}journey.serviceName{{/t}} &ndash; GOV.UK
+  {{/pageTitle}}
+  {{$bodyStart}}
+    <a href="#{{#skipToMain}}{{skipToMain}}{{/skipToMain}}{{^skipToMain}}main-content{{/skipToMain}}" class="govuk-skip-link" id="skip-to-main">Skip to main content</a>
+  {{/bodyStart}}
+  {{$headerClass}}govuk-header{{/headerClass}}
+  {{$insideHeader}}{{/insideHeader}}
+  {{$main}}
+	  <div class="govuk-width-container ">
+		{{#feedbackUrl}}
+			<div class="govuk-phase-banner">
+				<p class="govuk-phase-banner__content">
+				<strong class="govuk-tag govuk-phase-banner__content__tag">{{#t}}journey.phase{{/t}}</strong>
+				<span  class="govuk-phase-banner__text">This is a new service – your <a href="{{feedbackUrl}}{{^feedbackUrl}}https://eforms.homeoffice.gov.uk/outreach/feedback.ofml{{/feedbackUrl}}" class="govuk-link" id="feedback-link" target="_blank">feedback</a> will help us to improve it.</span>
+				</p>
+			</div>
+		{{/feedbackUrl}}      
+      <span id="step">
+        {{> partials-back}} <span>{{$step}}{{/step}}</span>
+      </span>
+	  <main class="govuk-main-wrapper govuk-main-wrapper--auto-spacing" id="main-content" role="main">
+		  <div class="govuk-grid-row" id="gov-grid-row-content">
+			{{> partials-maincontent-left}}
+		  </div>
+	  </main>
+      {{> partials-continue}}
+      <script type="text/javascript" src="{{assetPath}}/js/bundle.js"></script>
+	  </div>
+  {{/main}}
+  {{$cookieMessage}}
+    {{#gaTagId}}
+      {{> partials-cookie-banner}}
+    {{/gaTagId}}
+    {{^gaTagId}}
+      <p class="no-ga-tag">
+        {{#t}}cookies.banner.message{{/t}}
+        <a href="/cookies">{{#t}}cookies.banner.link{{/t}}</a>
+      </p>
+    {{/gaTagId}}
+  {{/cookieMessage}}
+  {{$footerSupportLinks}}
+    <ul class="govuk-footer__inline-list">
+      {{#footerSupportLinks}}
+        <li class="govuk-footer__inline-list-item"><a class="govuk-footer__link" href="{{path}}">{{#t}}{{property}}{{/t}}</a></li>
+      {{/footerSupportLinks}}
+      {{^footerSupportLinks}}
+        <li class="govuk-footer__inline-list-item"><a class="govuk-footer__link" href="/cookies">{{#t}}base.cookies{{/t}}</a></li>
+        <li class="govuk-footer__inline-list-item"><a  class="govuk-footer__link" href="/terms-and-conditions">{{#t}}base.terms{{/t}}</a></li>
+        <li class="govuk-footer__inline-list-item"><a  class="govuk-footer__link" href="/accessibility">{{#t}}base.accessibility{{/t}}</a></li>
+      {{/footerSupportLinks}}
+    </ul>
+  {{/footerSupportLinks}}
+  {{$bodyEnd}}
+    {{> partials-gatag}}
+  {{/bodyEnd}}
+{{/govuk-template}}

--- a/apps/lmr/views/privacy-declaration.html
+++ b/apps/lmr/views/privacy-declaration.html
@@ -1,9 +1,8 @@
-
 {{<partials-page}}
-{{$pageTitle}}
-{{#t}}pages.privacy-declaration.confirmed{{/t}} &ndash; {{#t}}journey.serviceName{{/t}} &ndash; GOV.UK
-{{/pageTitle}}
-{{$page-content}}
+  {{$pageTitle}}
+    {{#t}}pages.privacy-declaration.confirmed{{/t}} &ndash; {{#t}}journey.serviceName{{/t}} &ndash; GOV.UK
+  {{/pageTitle}}
+  {{$page-content}}
     <div class="govuk-panel alert-complete govuk-panel--confirmation">
       <h1 class="govuk-panel__title">
         {{#t}}pages.privacy-declaration.confirmed{{/t}}

--- a/apps/lmr/views/privacy-declaration.html
+++ b/apps/lmr/views/privacy-declaration.html
@@ -1,9 +1,9 @@
 
 {{<partials-page}}
 {{$pageTitle}}
-{{#t}}pages.privacy-declaration.title{{/t}} – GOV.UK
+{{#t}}pages.privacy-declaration.confirmed{{/t}} &ndash; {{#t}}journey.serviceName{{/t}} &ndash; GOV.UK
 {{/pageTitle}}
-  {{$page-content}}
+{{$page-content}}
     <div class="govuk-panel alert-complete govuk-panel--confirmation">
       <h1 class="govuk-panel__title">
         {{#t}}pages.privacy-declaration.confirmed{{/t}}

--- a/apps/lmr/views/privacy-declaration.html
+++ b/apps/lmr/views/privacy-declaration.html
@@ -1,5 +1,8 @@
-<title>{{#t}}pages.privacy-declaration.title{{/t}} – GOV.UK</title>
+
 {{<partials-page}}
+{{$pageTitle}}
+{{#t}}pages.privacy-declaration.title{{/t}} – GOV.UK
+{{/pageTitle}}
   {{$page-content}}
     <div class="govuk-panel alert-complete govuk-panel--confirmation">
       <h1 class="govuk-panel__title">

--- a/apps/lmr/views/privacy.html
+++ b/apps/lmr/views/privacy.html
@@ -1,7 +1,4 @@
 {{<partials-page}}
-{{$pageTitle}}
-{{#t}}pages.privacy.title{{/t}} – GOV.UK
-{{/pageTitle}}
   {{$page-content}}
     <p>{{#t}}pages.privacy.p1{{/t}}</p>
     <p>{{#t}}pages.privacy.p2{{/t}}</p>

--- a/apps/lmr/views/privacy.html
+++ b/apps/lmr/views/privacy.html
@@ -1,5 +1,7 @@
-<title>{{#t}}pages.privacy.title{{/t}} – GOV.UK</title>
 {{<partials-page}}
+{{$pageTitle}}
+{{#t}}pages.privacy.title{{/t}} – GOV.UK
+{{/pageTitle}}
   {{$page-content}}
     <p>{{#t}}pages.privacy.p1{{/t}}</p>
     <p>{{#t}}pages.privacy.p2{{/t}}</p>

--- a/apps/lmr/views/property-address.html
+++ b/apps/lmr/views/property-address.html
@@ -1,5 +1,7 @@
-<title>{{#t}}pages.property-address.title{{/t}} – GOV.UK</title>
 {{<partials-page}}
+  {{$pageTitle}}
+    {{#t}}pages.property-address.title{{/t}} – GOV.UK
+  {{/pageTitle}}
   {{$page-content}}
     <p>{{#t}}pages.property-address.p1{{/t}}</p>
     {{#renderField}}address-line-1{{/renderField}}

--- a/apps/lmr/views/property-address.html
+++ b/apps/lmr/views/property-address.html
@@ -1,7 +1,4 @@
 {{<partials-page}}
-  {{$pageTitle}}
-    {{#t}}pages.property-address.title{{/t}} – GOV.UK
-  {{/pageTitle}}
   {{$page-content}}
     <p>{{#t}}pages.property-address.p1{{/t}}</p>
     {{#renderField}}address-line-1{{/renderField}}

--- a/apps/lmr/views/start.html
+++ b/apps/lmr/views/start.html
@@ -1,5 +1,7 @@
-<title>{{#t}}pages.start.title{{/t}} – GOV.UK</title>
 {{<partials-page}}
+{{$pageTitle}}
+{{#t}}pages.start.title{{/t}} – GOV.UK
+{{/pageTitle}}
   {{$page-content}}
     <br>
     <p>{{#t}}pages.start.p1{{/t}}</p>

--- a/apps/lmr/views/start.html
+++ b/apps/lmr/views/start.html
@@ -1,7 +1,4 @@
 {{<partials-page}}
-{{$pageTitle}}
-{{#t}}pages.start.title{{/t}} – GOV.UK
-{{/pageTitle}}
   {{$page-content}}
     <br>
     <p>{{#t}}pages.start.p1{{/t}}</p>

--- a/apps/lmr/views/tenancy-start.html
+++ b/apps/lmr/views/tenancy-start.html
@@ -2,5 +2,5 @@
   {{$page-content}}
     {{#renderField}}move-date{{/renderField}}
     {{#input-submit}}continue{{/input-submit}}
-    {{/page-content}}
+  {{/page-content}}
 {{/partials-page}}

--- a/apps/lmr/views/tenancy-start.html
+++ b/apps/lmr/views/tenancy-start.html
@@ -1,7 +1,9 @@
-<title>{{#t}}pages.tenancy-start.title{{/t}} – GOV.UK</title>
 {{<partials-page}}
+{{$pageTitle}}
+{{#t}}pages.tenancy-start.title{{/t}} – GOV.UK
+{{/pageTitle}}
   {{$page-content}}
     {{#renderField}}move-date{{/renderField}}
     {{#input-submit}}continue{{/input-submit}}
-  {{/page-content}}
+    {{/page-content}}
 {{/partials-page}}

--- a/apps/lmr/views/tenancy-start.html
+++ b/apps/lmr/views/tenancy-start.html
@@ -1,7 +1,4 @@
 {{<partials-page}}
-{{$pageTitle}}
-{{#t}}pages.tenancy-start.title{{/t}} – GOV.UK
-{{/pageTitle}}
   {{$page-content}}
     {{#renderField}}move-date{{/renderField}}
     {{#input-submit}}continue{{/input-submit}}

--- a/apps/lmr/views/tenant-details.html
+++ b/apps/lmr/views/tenant-details.html
@@ -1,7 +1,4 @@
 {{<partials-page}}
-{{$pageTitle}}
-{{#t}}pages.tenant-details.title{{/t}} – GOV.UK
-{{/pageTitle}}
   {{$page-content}}
     {{#renderField}}tenant-full-name{{/renderField}}
     {{#renderField}}tenant-dob{{/renderField}}

--- a/apps/lmr/views/tenant-details.html
+++ b/apps/lmr/views/tenant-details.html
@@ -1,5 +1,7 @@
-<title>{{#t}}pages.tenant-details.title{{/t}} – GOV.UK</title>
 {{<partials-page}}
+{{$pageTitle}}
+{{#t}}pages.tenant-details.title{{/t}} – GOV.UK
+{{/pageTitle}}
   {{$page-content}}
     {{#renderField}}tenant-full-name{{/renderField}}
     {{#renderField}}tenant-dob{{/renderField}}


### PR DESCRIPTION
### What

- TLF LMR - LMR - Page titles should match h1 headings - [TLF-103](https://collaboration.homeoffice.gov.uk/jira/browse/TLF-103)

### Why

- Per the GDS Service Manual, titles should be unique and they should match the H1 heading. The html contains three <title> elements

### How

- Analysed and Identified the code changes to fix the mentioned issues. 
- Overwrite the layout file to get the title as expected [H1 - ServiceName - GOV.Uk]
- Added serviceName in "apps/lmr/translations/src/en/journey.json"
- Removed title property for all the pages in "apps/lmr/translations/src/en/pages.json"
- Removed <title> from all the template and only for privacyDeclaration.html - added the {{pageTitle}}
  

### Testing
- [x] Local testing passed
- [x] Unit test passed in Local
- [x] Test Lint Passed in Local
- [x] Pipeline Check Passed
- [x] Branch Testing passed 