### PR TITLE
TLF-29-add date accessibility testing was completed

### DIFF
--- a/apps/lmr/translations/src/en/pages.json
+++ b/apps/lmr/translations/src/en/pages.json
@@ -84,6 +84,8 @@
     }
   },
   "accessibility": {
-    "header": "Accessibility statement"
+    "header": "Accessibility statement",
+    "preparation-p1": "This statement was prepared on 19 April 2024. It was last reviewed on 19 April 2024.",
+    "preparation-p2": "This website was last tested on 18 March 2024. The test was carried out internally by the Home Office."
   }
 }

--- a/apps/lmr/views/accessibility.html
+++ b/apps/lmr/views/accessibility.html
@@ -46,8 +46,8 @@
     <h3 class="govuk-heading-m">{{#t}}accessibility.outside-scope-header{{/t}}</h3>
     <p class="govuk-body">{{#t}}accessibility.outside-scope-p1{{/t}}</p>
     <h2 class="govuk-heading-m">{{#t}}accessibility.preparation-header{{/t}}</h2>
-    <p class="govuk-body">{{#t}}accessibility.preparation-p1{{/t}}</p>
-    <p class="govuk-body">{{#t}}accessibility.preparation-p2{{/t}}</p>
+    <p class="govuk-body">{{#t}}pages.accessibility.preparation-p1{{/t}}</p>
+    <p class="govuk-body">{{#t}}pages.accessibility.preparation-p2{{/t}}</p>
     <p class="govuk-body">{{#t}}accessibility.preparation-p3{{/t}}</p>
   {{/page-content}}
 {{/partials-page}}


### PR DESCRIPTION
Relates: [TLF-29](https://collaboration.homeoffice.gov.uk/jira/browse/TLF-29)

What
* Add date accessibility testing was completed to LMR overriding default date in hof framework

Why
* Default date for the accessibility testing being completed is incorrect