### PR TITLE
LMR-4-Adding-PVC-to-service

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -13,12 +13,71 @@ export SCHEMA_ACTION=migrate
 
 kd='kd --insecure-skip-tls-verify --timeout 10m --check-interval 10s'
 
+normalize_redis_env() {
+  : "${REDIS_PERSISTENCE_ENABLED:=}"
+  : "${REDIS_PERSISTENCE_SIZE:=}"
+  : "${REDIS_PERSISTENCE_ACCESS_MODES:=ReadWriteOnce}"
+  : "${REDIS_PERSISTENCE_STORAGE_CLASS:=}"
+  : "${REDIS_PERSISTENCE_EXISTING_CLAIM:=}"
+  : "${REDIS_PERSISTENCE_ANNOTATIONS_FILE:=}"
+
+  REDIS_PERSISTENCE_ENABLED=$(echo "${REDIS_PERSISTENCE_ENABLED}" | tr '[:upper:]' '[:lower:]')
+
+  export REDIS_PERSISTENCE_ENABLED
+  export REDIS_PERSISTENCE_SIZE
+  export REDIS_PERSISTENCE_ACCESS_MODES
+  export REDIS_PERSISTENCE_STORAGE_CLASS
+  export REDIS_PERSISTENCE_EXISTING_CLAIM
+  export REDIS_PERSISTENCE_ANNOTATIONS_FILE
+}
+
+apply_redis_persistence_rules() {
+  if [[ "${KUBE_NAMESPACE}" == "${PROD_ENV}" ]]; then
+    REDIS_PERSISTENCE_ENABLED=true
+    REDIS_PERSISTENCE_SIZE=10Gi
+  elif [[ "${KUBE_NAMESPACE}" == "${STG_ENV}" ]]; then
+    REDIS_PERSISTENCE_ENABLED=true
+    REDIS_PERSISTENCE_SIZE=1Gi
+  else
+    REDIS_PERSISTENCE_ENABLED=false
+  fi
+
+  normalize_redis_env
+}
+
+deploy_redis() {
+  if [[ "${REDIS_PERSISTENCE_ENABLED}" == "true" && -z "${REDIS_PERSISTENCE_EXISTING_CLAIM}" ]]; then
+    if [[ -n "${REDIS_PERSISTENCE_ANNOTATIONS_FILE}" ]]; then
+      $kd -f kube/redis/redis-pvc.yml -f "${REDIS_PERSISTENCE_ANNOTATIONS_FILE}"
+    else
+      $kd -f kube/redis/redis-pvc.yml
+    fi
+  fi
+
+  $kd -f kube/redis/redis-service.yml -f kube/redis/redis-network-policy.yml -f kube/redis/redis-deployment.yml
+}
+
+delete_redis() {
+  $kd --delete -f kube/redis/redis-service.yml -f kube/redis/redis-network-policy.yml -f kube/redis/redis-deployment.yml
+
+  if [[ "${REDIS_PERSISTENCE_ENABLED}" == "true" && -z "${REDIS_PERSISTENCE_EXISTING_CLAIM}" ]]; then
+    if [[ -n "${REDIS_PERSISTENCE_ANNOTATIONS_FILE}" ]]; then
+      $kd --delete -f kube/redis/redis-pvc.yml -f "${REDIS_PERSISTENCE_ANNOTATIONS_FILE}"
+    else
+      $kd --delete -f kube/redis/redis-pvc.yml
+    fi
+  fi
+}
+
 if [[ $1 == 'tear_down' ]]; then
   export KUBE_NAMESPACE=$BRANCH_ENV
   export DRONE_SOURCE_BRANCH=$(cat /root/.dockersock/branch_name.txt)
 
+  apply_redis_persistence_rules
+
   $kd --delete -f kube/configmaps/configmap.yml
-  $kd --delete -f kube/html-pdf -f kube/app -f kube/redis 
+  $kd --delete -f kube/html-pdf -f kube/app
+  delete_redis
   echo "Torn Down Branch - $APP_NAME-$DRONE_SOURCE_BRANCH.internal.$BRANCH_ENV.homeoffice.gov.uk"
   exit 0
 fi
@@ -26,24 +85,30 @@ fi
 export KUBE_NAMESPACE=$1
 export DRONE_SOURCE_BRANCH=$(echo $DRONE_SOURCE_BRANCH | tr '[:upper:]' '[:lower:]' | tr '/' '-')
 
+apply_redis_persistence_rules
+
 if [[ ${KUBE_NAMESPACE} == ${BRANCH_ENV} ]]; then
   $kd -f kube/configmaps -f kube/certs
   $kd -f kube/html-pdf 
-  $kd -f kube/redis -f kube/app
+  deploy_redis
+  $kd -f kube/app
 elif [[ ${KUBE_NAMESPACE} == ${UAT_ENV} ]]; then
   $kd -f kube/configmaps/configmap.yml
   $kd -f kube/html-pdf
-  $kd -f kube/redis -f kube/app
+  deploy_redis
+  $kd -f kube/app
 elif [[ ${KUBE_NAMESPACE} == ${STG_ENV} ]]; then
   $kd -f kube/configmaps/configmap.yml -f kube/app/service.yml
   $kd -f kube/html-pdf
   $kd -f kube/app/ingress-internal.yml -f kube/app/networkpolicy-internal.yml
-  $kd -f kube/redis -f kube/app/deployment.yml
+  deploy_redis
+  $kd -f kube/app/deployment.yml
 elif [[ ${KUBE_NAMESPACE} == ${PROD_ENV} ]]; then
   $kd -f kube/configmaps/configmap.yml  -f kube/app/service.yml
   $kd -f kube/html-pdf
   $kd -f kube/app/ingress-external.yml -f kube/app/networkpolicy-external.yml
-  $kd -f kube/redis -f kube/app/deployment.yml
+  deploy_redis
+  $kd -f kube/app/deployment.yml
 fi
 
 sleep $READY_FOR_TEST_DELAY

--- a/kube/redis/redis-deployment.yml
+++ b/kube/redis/redis-deployment.yml
@@ -51,7 +51,11 @@ spec:
         - name: data
           {{ if eq .REDIS_PERSISTENCE_ENABLED "true" }}
           persistentVolumeClaim:
-            claimName: {{ if .REDIS_PERSISTENCE_EXISTING_CLAIM }}{{ .REDIS_PERSISTENCE_EXISTING_CLAIM }}{{ else }}redis-data{{ end }}
+            {{ if .REDIS_PERSISTENCE_EXISTING_CLAIM }}
+            claimName: {{ .REDIS_PERSISTENCE_EXISTING_CLAIM }}
+            {{ else }}
+            claimName: redis-data
+            {{ end }}
           {{ else }}
           emptyDir: {}
           {{ end }}

--- a/kube/redis/redis-deployment.yml
+++ b/kube/redis/redis-deployment.yml
@@ -9,6 +9,8 @@ metadata:
   {{ end }}
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
@@ -28,7 +30,11 @@ spec:
         service: redis
         app: redis
         {{ end }}
+    
     spec:
+      securityContext:
+        fsGroup: 994
+        fsGroupChangePolicy: OnRootMismatch
       containers:
         - name: redis
           # redis:v7.0.15

--- a/kube/redis/redis-deployment.yml
+++ b/kube/redis/redis-deployment.yml
@@ -49,4 +49,9 @@ spec:
               memory: "200Mi"
       volumes:
         - name: data
+          {{ if eq .REDIS_PERSISTENCE_ENABLED "true" }}
+          persistentVolumeClaim:
+            claimName: {{ if .REDIS_PERSISTENCE_EXISTING_CLAIM }}{{ .REDIS_PERSISTENCE_EXISTING_CLAIM }}{{ else }}redis-data{{ end }}
+          {{ else }}
           emptyDir: {}
+          {{ end }}

--- a/kube/redis/redis-pvc.yml
+++ b/kube/redis/redis-pvc.yml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: redis-data
+spec:
+  accessModes:
+    - "{{ .REDIS_PERSISTENCE_ACCESS_MODES }}"
+  resources:
+    requests:
+      storage: "{{ .REDIS_PERSISTENCE_SIZE }}"
+  {{ if .REDIS_PERSISTENCE_STORAGE_CLASS }}
+  storageClassName: "{{ .REDIS_PERSISTENCE_STORAGE_CLASS }}"
+  {{ end }}


### PR DESCRIPTION
## What? 
This pull request adds support for persistent storage for Redis deployments in Kubernetes, replacing ephemeral storage with persistent volumes and claims. It introduces new configuration files for `PersistentVolume` and `PersistentVolumeClaim` resources, and updates the Redis deployment to use these resources. The configuration is dynamic, supporting different environments (production, branch, etc.) with conditional naming and storage sizes.

Persistent storage support for Redis:

* Added `redis-persistent-volume.yml` to define a `PersistentVolume` with conditional naming and storage size based on the environment.
* Added `redis-persistent-volume-claim.yml` to define a `PersistentVolumeClaim` with conditional naming, storage class, and volume binding, supporting different sizes for production and non-production environments.
* Updated `redis-deployment.yml` to use a `persistentVolumeClaim` for the Redis data volume instead of an `emptyDir`, with claim names set dynamically based on the environment.
## Why? 
PersistentVolume ensures that data (like Redis cache/session state) survives pod restarts, rescheduling, or crashes — without it, everything stored in the container is lost the moment it stops running.

## How? 
Config changes

## Testing?
Restart pods and observe behaviour

## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [ ] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
