### PR TITLE
feat: adding custom dependabot configuration and branch sanitisation for PR's

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,30 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    versioning-strategy: increase
+    schedule:
+      interval: weekly
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/London"
+    target-branch: "master"
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+    commit-message:
+      prefix: deps
+    pull-request-branch-name:
+      separator: "-"
+    rebase-strategy: auto
+    groups:
+      hof-dependency:
+        applies-to: version-updates
+        patterns:
+          - "hof"
+      patch-and-minor:
+        update-types:
+          - patch
+          - minor
+        exclude-patterns:
+          - "hof"

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -13,6 +13,95 @@ export SCHEMA_ACTION=migrate
 
 kd='kd --insecure-skip-tls-verify --timeout 10m --check-interval 10s'
 
+compute_branch_slug_max_length() {
+  local dns_label_limit=63
+  local app_name_length=${#APP_NAME}
+  local max_for_app_name
+  local max_for_configmap_name
+  local max_branch_length
+
+  # ${APP_NAME}-${DRONE_SOURCE_BRANCH}
+  max_for_app_name=$((dns_label_limit - app_name_length - 1))
+
+  # ${APP_NAME}-configmap-${DRONE_SOURCE_BRANCH}
+  max_for_configmap_name=$((dns_label_limit - app_name_length - 11))
+
+  max_branch_length=$max_for_app_name
+  if (( max_for_configmap_name < max_branch_length )); then
+    max_branch_length=$max_for_configmap_name
+  fi
+
+  # Keep a small but usable floor even for long APP_NAME values.
+  if (( max_branch_length < 8 )); then
+    max_branch_length=8
+  fi
+
+  echo "$max_branch_length"
+}
+
+sanitize_branch_name() {
+  local raw_branch="$1"
+  local max_length="${2:-40}"
+  local dependabot_payload
+  local dependabot_dependency
+  local sanitized_branch
+
+  # Rewrite Dependabot npm/yarn base-branch update branches to a shorter, meaningful slug.
+  # Example: dependabot-npm_and_yarn-master-eslint-10.4.1 -> dependabot-pr-eslint
+  if [[ "$raw_branch" =~ ^dependabot[-/]npm_and_yarn[-/](master|main)[-/](.+)$ ]]; then
+    dependabot_payload="${BASH_REMATCH[2]}"
+    dependabot_payload=$(echo "$dependabot_payload" | tr '[:upper:]' '[:lower:]' | tr '/' '-')
+    dependabot_payload=$(echo "$dependabot_payload" | sed -E 's/[^a-z0-9-]+/-/g; s/^-+//; s/-+$//; s/-+/-/g')
+
+    if [[ -n "$dependabot_payload" ]]; then
+      dependabot_dependency="$dependabot_payload"
+
+      # Trim trailing version token if present (e.g. package-1-2-3).
+      if [[ "$dependabot_payload" =~ ^(.+)-([0-9][0-9a-z-]*)$ ]]; then
+        dependabot_dependency="${BASH_REMATCH[1]}"
+      # Trim trailing git hash token if present (e.g. package-b4f7b4df17).
+      elif [[ "$dependabot_payload" =~ ^(.+)-([a-f0-9]{7,40})$ ]]; then
+        dependabot_dependency="${BASH_REMATCH[1]}"
+      fi
+
+      dependabot_dependency=$(echo "$dependabot_dependency" | sed -E 's/^-+//; s/-+$//; s/-+/-/g')
+      if [[ -z "$dependabot_dependency" ]]; then
+        dependabot_dependency="dependency"
+      fi
+
+      sanitized_branch="dependabot-pr-${dependabot_dependency}"
+    fi
+  fi
+
+  if [[ -n "$sanitized_branch" ]]; then
+    sanitized_branch="${sanitized_branch:0:max_length}"
+    sanitized_branch=$(echo "$sanitized_branch" | sed -E 's/-+$//')
+
+    if [[ -z "$sanitized_branch" ]]; then
+      sanitized_branch='branch'
+    fi
+
+    echo "$sanitized_branch"
+    return
+  fi
+
+  sanitized_branch=$(echo "$raw_branch" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//; s/-+/-/g')
+
+  if [[ -z "$sanitized_branch" ]]; then
+    sanitized_branch='branch'
+  fi
+
+  # Keep branch slug short so generated Kubernetes resource names remain within DNS label limits.
+  sanitized_branch="${sanitized_branch:0:max_length}"
+  sanitized_branch=$(echo "$sanitized_branch" | sed -E 's/-+$//')
+
+  if [[ -z "$sanitized_branch" ]]; then
+    sanitized_branch='branch'
+  fi
+
+  echo "$sanitized_branch"
+}
+
 normalize_redis_env() {
   : "${REDIS_PERSISTENCE_ENABLED:=}"
   : "${REDIS_PERSISTENCE_SIZE:=}"
@@ -75,7 +164,8 @@ delete_redis() {
 
 if [[ $1 == 'tear_down' ]]; then
   export KUBE_NAMESPACE=$BRANCH_ENV
-  export DRONE_SOURCE_BRANCH=$(cat /root/.dockersock/branch_name.txt)
+  export BRANCH_SLUG_MAX_LENGTH=$(compute_branch_slug_max_length)
+  export DRONE_SOURCE_BRANCH=$(sanitize_branch_name "$(cat /root/.dockersock/branch_name.txt)" "${BRANCH_SLUG_MAX_LENGTH}")
 
   apply_redis_persistence_rules
 
@@ -87,7 +177,8 @@ if [[ $1 == 'tear_down' ]]; then
 fi
 
 export KUBE_NAMESPACE=$1
-export DRONE_SOURCE_BRANCH=$(echo $DRONE_SOURCE_BRANCH | tr '[:upper:]' '[:lower:]' | tr '/' '-')
+export BRANCH_SLUG_MAX_LENGTH=$(compute_branch_slug_max_length)
+export DRONE_SOURCE_BRANCH=$(sanitize_branch_name "${DRONE_SOURCE_BRANCH}" "${BRANCH_SLUG_MAX_LENGTH}")
 
 apply_redis_persistence_rules
 


### PR DESCRIPTION
## What?

This PR adds custom dependabot config to run weekly, which will generate PR's against the services to update both the package.json and yarn.lock files when a package update is detected. It also adds extra branch name sanitisation for PR's which are raised by dependabot, to ensure they meet the restrictions in place by ACP.

## Why?

We need custom handling of dependabot PR's to ensure proper updates can occur to the service.

## How?
## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [X] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [ ] I have created a JIRA number for my branch
- [ ] I have created a JIRA number for my commit
- [X] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [X] Ensure drone builds are green especially tests
- [X] I will squash the commits before merging
